### PR TITLE
fix build error with biliip enabled

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -798,6 +798,7 @@ int main(
     ctl.probe_timeout = 10 * 1000000;
     ctl.ipinfo_no = -1;
     ctl.ipinfo_max = -1;
+    ctl.biliip_BASE_PTR = 5;
     xstrncpy(ctl.fld_active, "LS NABWV", 2 * MAXFLD);
 
     setlocale(LC_ALL,"");

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -118,6 +118,7 @@ struct mtr_ctl {
     ipdb_reader *reader;
 #endif
 #ifdef ENABLE_BILIIP
+    int biliip_BASE_PTR;
     struct bb_biliip *biliip;
 #endif
     int ipinfo_no;


### PR DESCRIPTION
fix build error with biliip enabled
```
ui/mtr.c:887:35: error: no member named 'biliip_BASE_PTR' in 'struct mtr_ctl'
        fseek(ctl.biliip->fp, ctl.biliip_BASE_PTR, SEEK_SET);
```